### PR TITLE
Link CSS Formatting Addition

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -36,6 +36,10 @@ h1, h2, h3, h4, h5, h6, p, b, li, ul {
 h1 {font-size: 32px;}
 h2 {font-size: 24px;}
 
+a {
+    color: #54FC54
+}
+
 p {
     font-size: 17px;
 }


### PR DESCRIPTION
Links by default show dark blue on a black background and it's rough on the eyes.

This makes links show the same green color as the "Back to home" button does. Color can be changed, but something needs to be set.